### PR TITLE
Fix: package netstandard2.1 using PackageOutputPath

### DIFF
--- a/build/build.fs
+++ b/build/build.fs
@@ -825,7 +825,7 @@ let dotnetPack ctx =
     let args = [
         $"/p:PackageVersion={latestEntry.NuGetVersion}"
         $"/p:PackageReleaseNotes=\"{releaseNotes}\""
-        $"/p:OutputPath={distDir}" // https://learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/7.0/solution-level-output-no-longer-valid
+        $"/p:PackageOutputPath={distDir}" // https://learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/7.0/solution-level-output-no-longer-valid
     ]
 
     DotNet.pack


### PR DESCRIPTION
## Proposed Changes

This is a fix for #20, to package correctly the netstandard2.1 in the nuget.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] Build and tests pass locally
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Further comments


dotnet SDK 7.0.200 doesn't use the `-o` flag anymore. The build had been updated to use the `OutputPath` property, but this caused a problem with the multitargetting: all targets were compiled to the same directory. Once packed, all targets in the package contained the same netstandard2.0 dll.

Using `PackageOutputPath`, the build is still done in `bin/Release/{TargetFramework}` dirs, only the nuget is at specified location.
