### PR TITLE
Polyfill fixes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,8 @@
     ],
     "[fsharp]": {
         "editor.formatOnSave": true
-    }
+    },
+    "cSpell.words": [
+        "backported"
+    ]
 }

--- a/README.md
+++ b/README.md
@@ -25,12 +25,14 @@ This library contains additional [computation expressions](https://docs.microsof
 
 - `AsyncEx<'T>` - Variation of F# async semantics described further below with examples.
     - `asyncEx`
+    - This can also be accessed under `IcedTasks.Polyfill.Async` which will [shadow](https://stackoverflow.com/a/39645319) the F# Async CE.
+      - `async`
 
-- `Task<'T>` - Polyfill for fixes to F# Task CE. Can be accessed under `IcedTasks.Polyfill`
+- `Task<'T>` - Polyfill for fixes to F# Task CE. Can be accessed under `IcedTasks.Polyfill.Task` which will [shadow](https://stackoverflow.com/a/39645319) the F# Task CE.
     - `task`
     - `backgroundTask`
 
-- `Task` - a CE for a`Task` that has no return value.
+- `Task` - a CE for a `Task` that has no return value.
     - `taskUnit`
     - `backgroundTaskUnit`
 

--- a/src/IcedTasks/Task.fs
+++ b/src/IcedTasks/Task.fs
@@ -9,11 +9,11 @@
 // To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights
 // to this software to the public domain worldwide. This software is distributed without any warranty.
 
-namespace IcedTasks.Polyfill
+namespace IcedTasks.Polyfill.Task
 
 /// Contains methods to build Tasks using the F# computation expression syntax
 [<AutoOpen>]
-module TasksUnit =
+module Tasks =
     open System
     open System.Runtime.CompilerServices
     open System.Threading
@@ -220,14 +220,18 @@ module TasksUnit =
 
     /// Contains the task computation expression builder.
     [<AutoOpen>]
-    module TaskUnitBuilder =
+    module TaskBuilder =
 
         /// <summary>
-        /// Builds a task using computation expression syntax.
+        /// Builds a task using computation expression syntax
+        ///
+        /// <b>NOTE:</b> This is the TaskBuilder defined in IcedTasks. This fixes any issues with the TaskBuilder defined in FSharp.Core that can't be backported.
         /// </summary>
         let task = TaskBuilder()
 
         /// <summary>
         /// Builds a task using computation expression syntax which switches to execute on a background thread if not already doing so.
+        ///
+        /// <b>NOTE:</b> This is the BackgroundTaskBuilder defined in IcedTasks. This fixes any issues with the BackgroundTaskBuilder defined in FSharp.Core that can't be backported.
         /// </summary>
         let backgroundTask = BackgroundTaskBuilder()

--- a/src/IcedTasks/TaskBuilderBase.fs
+++ b/src/IcedTasks/TaskBuilderBase.fs
@@ -209,7 +209,6 @@ module TaskBase =
 
                     if __useResumableCode then
                         let mutable __stack_condition_fin = true
-                        // let __stack_vtask = compensation ()
                         let mutable awaiter = compensation ()
 
                         if not (Awaiter.IsCompleted awaiter) then
@@ -227,7 +226,6 @@ module TaskBase =
 
                         __stack_condition_fin
                     else
-                        // let vtask = compensation ()
                         let mutable awaiter = compensation ()
 
                         let cont =

--- a/tests/IcedTasks.Tests/CancellableTaskTests.fs
+++ b/tests/IcedTasks.Tests/CancellableTaskTests.fs
@@ -5,7 +5,7 @@ open Expecto
 open System.Threading
 open System.Threading.Tasks
 open IcedTasks
-#if !NETSTANDARD2_0
+#if TEST_NETSTANDARD2_1 || TEST_NET6_0_OR_GREATER
 open IcedTasks.ValueTaskExtensions
 #endif
 module CancellableTaskTests =
@@ -182,7 +182,7 @@ module CancellableTaskTests =
 
                     Expect.equal actual expected ""
                 }
-#if !NETSTANDARD2_0
+#if TEST_NETSTANDARD2_1 || TEST_NET6_0_OR_GREATER
                 testCaseAsync "Can Bind Cancellable TaskLike"
                 <| async {
                     let fooTask = fun (ct: CancellationToken) -> Task.Yield()

--- a/tests/IcedTasks.Tests/ColdTaskTests.fs
+++ b/tests/IcedTasks.Tests/ColdTaskTests.fs
@@ -421,7 +421,7 @@ module ColdTaskTests =
                 }
 
 
-#if !NETSTANDARD2_0
+#if TEST_NETSTANDARD2_1 || TEST_NET6_0_OR_GREATER
                 testCaseAsync "use IAsyncDisposable sync"
                 <| async {
                     let data = 42

--- a/tests/IcedTasks.Tests/Expect.fs
+++ b/tests/IcedTasks.Tests/Expect.fs
@@ -57,7 +57,7 @@ module Expect =
             message
         |> Async.StartImmediateAsTask
 
-#if !NETSTANDARD2_0
+#if TEST_NETSTANDARD2_1 || TEST_NET6_0_OR_GREATER
     [<RequiresExplicitTypeArguments>]
     let throwsValueTask<'texn when 'texn :> exn> (f: unit -> ValueTask<unit>) message =
         throwsTAsync<'texn>
@@ -75,7 +75,7 @@ type Expect =
             (fun () -> operation)
             "Should have been cancelled"
 
-#if !NETSTANDARD2_0
+#if TEST_NETSTANDARD2_1 || TEST_NET6_0_OR_GREATER
     static member CancellationRequested(operation: ValueTask<unit>) =
         Expect.CancellationRequested(Async.AwaitValueTask operation)
         |> Async.AsValueTask
@@ -92,7 +92,7 @@ type Expect =
         Expect.CancellationRequested(Async.AwaitCancellableTask operation)
         |> Async.AsCancellableTask
 
-#if !NETSTANDARD2_0
+#if TEST_NETSTANDARD2_1 || TEST_NET6_0_OR_GREATER
     static member CancellationRequested(operation: CancellableValueTask<_>) =
         Expect.CancellationRequested(Async.AwaitCancellableValueTask operation)
         |> Async.AsCancellableValueTask

--- a/tests/IcedTasks.Tests/TaskBackgroundTests.fs
+++ b/tests/IcedTasks.Tests/TaskBackgroundTests.fs
@@ -5,7 +5,7 @@ open Expecto
 open System.Threading
 open System.Threading.Tasks
 open IcedTasks
-open IcedTasks.Polyfill
+open IcedTasks.Polyfill.Task
 
 module TaskBackgroundTests =
 

--- a/tests/IcedTasks.Tests/TaskDynamicTests.fs
+++ b/tests/IcedTasks.Tests/TaskDynamicTests.fs
@@ -7,7 +7,7 @@ open Expecto
 open System.Threading
 open System.Threading.Tasks
 open IcedTasks
-open IcedTasks.Polyfill
+open IcedTasks.Polyfill.Task
 
 module TaskDynamicTests =
     open System.Runtime.CompilerServices

--- a/tests/IcedTasks.Tests/TaskTests.fs
+++ b/tests/IcedTasks.Tests/TaskTests.fs
@@ -2,10 +2,9 @@ namespace IcedTasks.Tests
 
 open System
 open Expecto
-open System.Threading
 open System.Threading.Tasks
 open IcedTasks
-open IcedTasks.Polyfill
+open IcedTasks.Polyfill.Task
 
 module TaskTests =
 


### PR DESCRIPTION
## Proposed Changes

- Puts `task` and `async` in to `IcedTasks.Polyfill.Task` and `IcedTasks.Polyfill.Async` respectively
- Fixes `CancellableTask*` not inferring `CancellableTask<unit>` when:
    - ```fsharp 
      cancellableTask { do! Task.Yield () } 
      ```

## Types of changes

What types of changes does your code introduce to IcedTasks?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Build and tests pass locally
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
