### PR TITLE
Use Microsoft.Bcl.AsyncInterfaces in netstandard2.0

### DIFF
--- a/build/build.fs
+++ b/build/build.fs
@@ -238,7 +238,6 @@ module DocsTool =
     let build (configuration) =
         Fsdocs.build fsDocsDotnetOptions (fsDocsBuildParams configuration)
 
-
     let watch (configuration) =
         let buildParams bp =
             let bp =
@@ -276,7 +275,7 @@ let maxCpuMsBuild =
     lazy
         (match maxCpuCount.Value with
          | None -> ""
-         | Some None -> "/m:"
+         | Some None -> "/m"
          | Some(Some x) -> $"/m:%d{x}")
 
 let allPublishChecks () =

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -7,6 +7,7 @@ nuget FSharp.Core >= 6.0.1
 nuget Microsoft.SourceLink.GitHub 1.1.1 copy_local: true
 nuget BenchmarkDotNet >= 0.13.9
 nuget Ply >= 0.3.1
+nuget Microsoft.Bcl.AsyncInterfaces >= 6.0.0 framework:netstandard2.0
 
 
 group Test
@@ -15,6 +16,7 @@ group Test
   source https://api.nuget.org/v3/index.json
   nuget Expecto >= 10.1.0
   nuget Microsoft.Bcl.TimeProvider
+  nuget Microsoft.Bcl.AsyncInterfaces >= 8
   nuget TimeProviderExtensions
   nuget YoloDev.Expecto.TestSdk >= 0.14.2
   nuget Microsoft.NET.Test.Sdk >= 17.7.2

--- a/paket.lock
+++ b/paket.lock
@@ -24,8 +24,8 @@ NUGET
     FSharp.Core (6.0.1)
     Gee.External.Capstone (2.3) - restriction: >= netstandard2.0
     Iced (1.17) - restriction: >= netstandard2.0
-    Microsoft.Bcl.AsyncInterfaces (1.1) - restriction: >= netstandard2.0
-      System.Threading.Tasks.Extensions (>= 4.5.2) - restriction: || (>= net461) (&& (< netcoreapp2.1) (>= netstandard2.0) (< netstandard2.1)) (&& (< netcoreapp2.1) (>= netstandard2.1))
+    Microsoft.Bcl.AsyncInterfaces (6.0) - restriction: == netstandard2.0
+      System.Threading.Tasks.Extensions (>= 4.5.4) - restriction: || (>= net461) (&& (>= netstandard2.0) (< netstandard2.1))
     Microsoft.Build.Tasks.Git (1.1.1) - copy_local: true
     Microsoft.CodeAnalysis.Analyzers (3.3.3) - restriction: >= netstandard2.0
     Microsoft.CodeAnalysis.Common (4.1) - restriction: >= netstandard2.0
@@ -112,7 +112,7 @@ NUGET
     System.Text.Encoding.CodePages (4.5.1) - restriction: >= netstandard2.0
       Microsoft.NETCore.Platforms (>= 2.1.2) - restriction: && (>= netcoreapp2.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime.CompilerServices.Unsafe (>= 4.5.2) - restriction: || (&& (< net46) (< netcoreapp2.0) (>= netstandard2.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= net461) (&& (>= netcoreapp2.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    System.Threading.Tasks.Extensions (4.5.4) - restriction: || (&& (< netcoreapp2.1) (>= netstandard2.1)) (>= netstandard2.0)
+    System.Threading.Tasks.Extensions (4.5.4) - restriction: >= netstandard2.0
       System.Runtime.CompilerServices.Unsafe (>= 4.5.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< netstandard2.0) (< win8) (< wpa81) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< netstandard1.0) (>= portable-net45+win8+wp8+wpa81) (< win8)) (&& (>= net45) (< netstandard2.0)) (&& (< net45) (< netcoreapp2.1) (>= netstandard2.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= net461) (&& (< netstandard1.0) (>= win8)) (&& (< netstandard2.0) (>= wpa81)) (>= wp8)
 
 GROUP Build
@@ -367,7 +367,7 @@ NUGET
     FSharp.Control.TaskSeq (0.3)
       FSharp.Core (>= 6.0.2) - restriction: >= netstandard2.1
     FSharp.Core (7.0.401) - restriction: >= netstandard2.1
-    Microsoft.Bcl.AsyncInterfaces (7.0) - restriction: || (>= net462) (&& (< net8.0) (>= netstandard2.0))
+    Microsoft.Bcl.AsyncInterfaces (8.0)
       System.Threading.Tasks.Extensions (>= 4.5.4) - restriction: || (>= net462) (&& (>= netstandard2.0) (< netstandard2.1))
     Microsoft.Bcl.TimeProvider (8.0)
       Microsoft.Bcl.AsyncInterfaces (>= 6.0) - restriction: || (>= net462) (&& (< net8.0) (>= netstandard2.0))

--- a/src/IcedTasks/AsyncEx.fs
+++ b/src/IcedTasks/AsyncEx.fs
@@ -155,7 +155,6 @@ type AsyncEx =
                 )
                 |> ignore
         )
-#if NETSTANDARD2_1 || NET6_0_OR_GREATER
 
 
     /// <summary>
@@ -191,7 +190,6 @@ type AsyncEx =
         else
             AsyncEx.AwaitTask(vTask.AsTask())
 
-#endif
 
 /// <exclude/>
 [<AutoOpen>]
@@ -274,8 +272,6 @@ type AsyncExBuilder() =
     member inline _.Bind(computation: Async<'f>, [<InlineIfLambda>] binder: 'f -> Async<'f0>) =
         async.Bind(computation, binder)
 
-#if NETSTANDARD2_1 || NET6_0_OR_GREATER
-
     member inline _.TryFinallyAsync
         (
             computation: Async<'ok>,
@@ -338,7 +334,6 @@ type AsyncExBuilder() =
                 )
         )
 
-#endif
     member inline _.While([<InlineIfLambda>] guard: unit -> bool, computation: Async<unit>) =
         async.While(guard, computation)
 
@@ -412,9 +407,8 @@ module AsyncExExtensionsHighPriority =
 
     type AsyncExBuilder with
 
-#if NETSTANDARD2_1 || NET6_0_OR_GREATER
         member inline _.Source(seq: #IAsyncEnumerable<_>) = seq
-#endif
+
         // Required because SRTP can't determine the type of the awaiter
         //     Candidates:
         //  - Task.GetAwaiter() : Runtime.CompilerServices.TaskAwaiter
@@ -423,11 +417,10 @@ module AsyncExExtensionsHighPriority =
 
         member inline _.Source(task: Task) = AsyncEx.AwaitTask task
 
-#if NETSTANDARD2_1 || NET6_0_OR_GREATER
         member inline _.Source(vtask: ValueTask<_>) = AsyncEx.AwaitValueTask vtask
 
         member inline _.Source(vtask: ValueTask) = AsyncEx.AwaitValueTask vtask
-#endif
+
 namespace IcedTasks.Polyfill.Async
 
 /// <namespacedoc>

--- a/src/IcedTasks/AsyncEx.fs
+++ b/src/IcedTasks/AsyncEx.fs
@@ -272,17 +272,13 @@ type AsyncExBuilder() =
     member inline _.Bind(computation: Async<'f>, [<InlineIfLambda>] binder: 'f -> Async<'f0>) =
         async.Bind(computation, binder)
 
-    member inline _.TryFinallyAsync
+    member inline this.TryFinallyAsync
         (
             computation: Async<'ok>,
             [<InlineIfLambda>] compensation: unit -> ValueTask
         ) : Async<'ok> =
 
-        let compensation =
-            async {
-                let vTask = compensation ()
-                return! Async.AwaitValueTask vTask
-            }
+        let compensation = this.Delay(fun () -> AsyncEx.AwaitValueTask(compensation ()))
 
         Async.TryFinallyAsync(computation, compensation)
 
@@ -327,7 +323,7 @@ type AsyncExBuilder() =
                                 enumerator.MoveNextAsync()
                                 |> AsyncEx.AwaitValueTask
                             )),
-                            (body enumerator.Current)
+                            (this.Delay(fun () -> body enumerator.Current))
                         )
 
                     )

--- a/src/IcedTasks/CancellableTask.fs
+++ b/src/IcedTasks/CancellableTask.fs
@@ -377,12 +377,7 @@ module CancellableTasks =
         /// followed by "Tasks Finished".
         /// </example>
         let inline getCancellationToken () =
-            fun (ct: CancellationToken) ->
-#if NETSTANDARD2_1 || NET6_0_OR_GREATER
-                ValueTask<CancellationToken> ct
-#else
-                Task.FromResult ct
-#endif
+            fun (ct: CancellationToken) -> ValueTask<CancellationToken> ct
 
         /// <summary>Lifts an item to a CancellableTask.</summary>
         /// <param name="item">The item to be the result of the CancellableTask.</param>

--- a/src/IcedTasks/CancellableTaskBuilderBase.fs
+++ b/src/IcedTasks/CancellableTaskBuilderBase.fs
@@ -194,7 +194,7 @@ module CancellableTaskBase =
                 body: 'T -> CancellableTaskBaseCode<'TOverall, unit, 'Builder>
             ) : CancellableTaskBaseCode<'TOverall, unit, 'Builder> =
             ResumableCode.For(sequence, body)
-#if NETSTANDARD2_1 || NET6_0_OR_GREATER
+
         /// <summary>Creates A CancellableTask that runs computation. The action compensation is executed
         /// after computation completes, whether computation exits normally or by an exception. If compensation raises an exception itself
         /// the original exception is discarded and the new exception becomes the overall result of the computation.</summary>
@@ -379,8 +379,6 @@ module CancellableTaskBase =
                     )
                     .Invoke(&sm)
             )
-#endif
-
 
     /// <exclude/>
     [<AutoOpen>]
@@ -764,14 +762,12 @@ module CancellableTaskBase =
         // High priority extensions
         type CancellableTaskBuilderBase with
 
-#if NETSTANDARD2_1 || NET6_0_OR_GREATER
             /// <summary>Allows the computation expression to turn other types into other types</summary>
             ///
             /// <remarks>This is the identify function for For binds.</remarks>
             ///
             /// <returns>IEnumerable</returns>
             member inline _.Source(s: #IAsyncEnumerable<_>) = s
-#endif
 
             /// <summary>Allows the computation expression to turn other types into CancellationToken -> 'Awaiter</summary>
             ///

--- a/src/IcedTasks/CancellableValueTask.fs
+++ b/src/IcedTasks/CancellableValueTask.fs
@@ -11,7 +11,6 @@
 
 namespace IcedTasks
 
-#if NETSTANDARD2_1 || NET6_0_OR_GREATER
 
 /// Contains methods to build CancellableTasks using the F# computation expression syntax
 [<AutoOpen>]
@@ -456,4 +455,3 @@ module CancellableValueTasks =
             fun ct ->
                 cancellableTask ct
                 |> ValueTask.toUnit
-#endif

--- a/src/IcedTasks/ColdTask.fs
+++ b/src/IcedTasks/ColdTask.fs
@@ -196,7 +196,6 @@ module ColdTasks =
             ) : ColdTaskCode<'TOverall, unit> =
             ResumableCode.For(sequence, body)
 
-#if NETSTANDARD2_1 || NET6_0_OR_GREATER
         /// <summary>Creates an ColdTask that runs computation. The action compensation is executed
         /// after computation completes, whether computation exits normally or by an exception. If compensation raises an exception itself
         /// the original exception is discarded and the new exception becomes the overall result of the computation.</summary>
@@ -287,7 +286,6 @@ module ColdTasks =
                 )
             )
 
-#endif
     /// Contains methods to build ColdTasks using the F# computation expression syntax
     type ColdTaskBuilder() =
 

--- a/src/IcedTasks/TaskBuilderBase.fs
+++ b/src/IcedTasks/TaskBuilderBase.fs
@@ -164,7 +164,6 @@ module TaskBase =
                 )
             )
 
-#if NETSTANDARD2_1 || NET6_0_OR_GREATER
         /// <summary>Creates a Task that runs computation. The action compensation is executed
         /// after computation completes, whether computation exits normally or by an exception. If compensation raises an exception itself
         /// the original exception is discarded and the new exception becomes the overall result of the computation.</summary>
@@ -345,7 +344,6 @@ module TaskBase =
                     )
                     .Invoke(&sm)
             )
-#endif
 
         /// <summary>Creates a Task that enumerates the sequence seq
         /// on demand and runs body for each element.</summary>
@@ -550,14 +548,12 @@ module TaskBase =
         // High priority extensions
         type TaskBuilderBase with
 
-#if NETSTANDARD2_1 || NET6_0_OR_GREATER
             /// <summary>Allows the computation expression to turn other types into other types</summary>
             ///
             /// <remarks>This is the identify function for For binds.</remarks>
             ///
             /// <returns>IEnumerable</returns>
             member inline _.Source(s: #IAsyncEnumerable<_>) = s
-#endif
 
 
             /// <summary>Allows the computation expression to turn other types into 'Awaiter</summary>

--- a/src/IcedTasks/ValueTask.fs
+++ b/src/IcedTasks/ValueTask.fs
@@ -3,7 +3,6 @@ namespace IcedTasks
 
 open System.Threading.Tasks
 
-#if NETSTANDARD2_1 || NET6_0_OR_GREATER
 
 /// <summary>
 /// Module with extension methods for <see cref="T:System.Threading.Tasks.ValueTask`1"/>.
@@ -310,6 +309,3 @@ module ValueTasks =
                 ValueTask()
             else
                 ValueTask(vtask.AsTask())
-
-
-#endif

--- a/src/IcedTasks/ValueTaskUnit.fs
+++ b/src/IcedTasks/ValueTaskUnit.fs
@@ -41,7 +41,9 @@ module ValueTasksUnit =
         /// <summary>
         /// The entry point for the dynamic implementation of the corresponding operation. Do not use directly, only used when executing quotations that involve tasks or other reflective execution of F# code.
         /// </summary>
-        static member inline RunDynamic(code: TaskBaseCode<'T, 'T, _>) : ValueTask =
+        static member inline RunDynamic
+            (code: TaskBaseCode<'T, 'T, AsyncValueTaskMethodBuilder>)
+            : ValueTask =
 
             let mutable sm = TaskBaseStateMachine<'T, _>()
 
@@ -58,7 +60,12 @@ module ValueTasksUnit =
                             let step = info.ResumptionFunc.Invoke(&sm)
 
                             if step then
+#if DEBUG
+                                sm.Data.MethodBuilder.SetResult()
+#else
+                                // SRTP fails here for some reason in debug mode
                                 MethodBuilder.SetResult(&sm.Data.MethodBuilder)
+#endif
                             else
                                 let mutable awaiter =
                                     sm.ResumptionDynamicInfo.ResumptionData
@@ -80,6 +87,7 @@ module ValueTasksUnit =
                         | exn -> MethodBuilder.SetException(&sm.Data.MethodBuilder, exn)
 
                     member _.SetStateMachine(sm, state) =
+
                         MethodBuilder.SetStateMachine(&sm.Data.MethodBuilder, state)
                 }
 
@@ -89,9 +97,9 @@ module ValueTasksUnit =
             MethodBuilder.get_Task (&sm.Data.MethodBuilder)
 
         /// Hosts the task code in a state machine and starts the task.
-        member inline _.Run(code: TaskBaseCode<'T, 'T, _>) : ValueTask =
+        member inline _.Run(code: TaskBaseCode<'T, 'T, AsyncValueTaskMethodBuilder>) : ValueTask =
             if __useResumableCode then
-                __stateMachine<TaskBaseStateMachineData<'T, _>, ValueTask>
+                __stateMachine<TaskBaseStateMachineData<'T, AsyncValueTaskMethodBuilder>, ValueTask>
                     (MoveNextMethodImpl<_>(fun sm ->
                         //-- RESUMABLE CODE START
                         __resumeAt sm.ResumptionPoint
@@ -101,7 +109,12 @@ module ValueTasksUnit =
                             let __stack_code_fin = code.Invoke(&sm)
 
                             if __stack_code_fin then
+#if DEBUG
+                                sm.Data.MethodBuilder.SetResult()
+#else
+                                // SRTP fails here for some reason in debug mode
                                 MethodBuilder.SetResult(&sm.Data.MethodBuilder)
+#endif
                         with exn ->
                             __stack_exn <- exn
                         // Run SetException outside the stack unwind, see https://github.com/dotnet/roslyn/issues/26567

--- a/src/IcedTasks/ValueTaskUnit.fs
+++ b/src/IcedTasks/ValueTaskUnit.fs
@@ -1,8 +1,6 @@
 namespace IcedTasks
 
 
-#if NETSTANDARD2_1 || NET6_0_OR_GREATER
-
 // Task builder for F# that compiles to allocation-free paths for synchronous code.
 //
 // Originally written in 2016 by Robert Peele (humbobst@gmail.com)
@@ -148,5 +146,3 @@ module ValueTasksUnit =
         /// Builds a valueTask using computation expression syntax.
         /// </summary>
         let vTaskUnit = valueTaskUnit
-
-#endif

--- a/src/IcedTasks/paket.references
+++ b/src/IcedTasks/paket.references
@@ -1,3 +1,3 @@
 FSharp.Core
 Microsoft.SourceLink.GitHub
-
+Microsoft.Bcl.AsyncInterfaces

--- a/tests/IcedTasks.Tests.NS20/IcedTasks.Tests.NS20.fsproj
+++ b/tests/IcedTasks.Tests.NS20/IcedTasks.Tests.NS20.fsproj
@@ -4,18 +4,21 @@
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net8.0;net6.0;net7.0</TargetFrameworks>
     <GenerateProgramFile>false</GenerateProgramFile>
-    <DefineConstants>$(DefineConstants);NETSTANDARD2_0;TEST_NETSTANDARD2_0</DefineConstants>
+<DefineConstants>$(DefineConstants);NETSTANDARD2_0;TEST_NETSTANDARD2_0</DefineConstants>
   </PropertyGroup>
     <ItemGroup>
         <ProjectReference Include="../../src/IcedTasks/IcedTasks.fsproj" AdditionalProperties="TargetFramework=netstandard2.0" />
-    </ItemGroup>
+           </ItemGroup>
   <ItemGroup>
     <Compile Include="../IcedTasks.Tests/Expect.fs" />
     <Compile Include="../IcedTasks.Tests/AsyncExTests.fs" />
     <Compile Include="../IcedTasks.Tests/TaskTests.fs" />
     <Compile Include="../IcedTasks.Tests/TaskBackgroundTests.fs" />
     <Compile Include="../IcedTasks.Tests/TaskDynamicTests.fs" />
+    <Compile Include="../IcedTasks.Tests/ValueTaskTests.fs" />
+    <Compile Include="../IcedTasks.Tests/ValueTaskDynamicTests.fs" />
     <Compile Include="../IcedTasks.Tests/CancellableTaskTests.fs" />
+    <Compile Include="../IcedTasks.Tests/CancellableValueTaskTests.fs" />
     <Compile Include="../IcedTasks.Tests/ColdTaskTests.fs" />
     <Compile Include="../IcedTasks.Tests/ParallelAsyncTests.fs" />
     <Compile Include="../IcedTasks.Tests/Main.fs" />

--- a/tests/IcedTasks.Tests.NS20/paket.references
+++ b/tests/IcedTasks.Tests.NS20/paket.references
@@ -4,3 +4,4 @@ Expecto
 Microsoft.NET.Test.Sdk
 YoloDev.Expecto.TestSdk
 TimeProviderExtensions
+Microsoft.Bcl.AsyncInterfaces

--- a/tests/IcedTasks.Tests/AsyncExTests.fs
+++ b/tests/IcedTasks.Tests/AsyncExTests.fs
@@ -54,7 +54,6 @@ module AsyncExTests =
                     let! result = outer
                     Expect.equal result () "Should return the data"
                 }
-#if TEST_NETSTANDARD2_1 || TEST_NET6_0_OR_GREATER
                 testCaseAsync "Can ReturnFrom a ValueTask<T>"
                 <| async {
                     let data = "foo"
@@ -70,7 +69,6 @@ module AsyncExTests =
                     let! result = outer
                     Expect.equal result () "Should return the data"
                 }
-#endif
                 testCaseAsync "Can ReturnFrom an TaskLike"
                 <| async {
                     let inner = Task.Yield()
@@ -135,7 +133,6 @@ module AsyncExTests =
                     let! result = outer
                     Expect.equal result () "Should return the data"
                 }
-#if TEST_NETSTANDARD2_1 || TEST_NET6_0_OR_GREATER
                 testCaseAsync "Can bind a ValueTask<T>"
                 <| async {
                     let data = "foo"
@@ -163,7 +160,7 @@ module AsyncExTests =
                     let! result = outer
                     Expect.equal result () "Should return the data"
                 }
-#endif
+
                 testCaseAsync "Can bind an TaskLike"
                 <| async {
                     let inner = Task.Yield()
@@ -298,7 +295,6 @@ module AsyncExTests =
                     let! result = outer
                     Expect.equal result () "Should return the data"
                 }
-#if TEST_NETSTANDARD2_1 || TEST_NET6_0_OR_GREATER
                 testCaseAsync
                     "Awaiting Failed ValueTask<'T> should only contain one exception and not aggregation"
                 <| async {
@@ -333,7 +329,7 @@ module AsyncExTests =
                     let! result = outer
                     Expect.equal result () "Should return the data"
                 }
-#endif
+
                 testCaseAsync
                     "Awaiting Failed CustomAwaiter should only contain one exception and not aggregation"
                 <| async {
@@ -428,7 +424,6 @@ module AsyncExTests =
                     Expect.equal actual data "Should be able to use use"
                     Expect.isTrue wasDisposed ""
                 }
-#if TEST_NETSTANDARD2_1 || TEST_NET6_0_OR_GREATER
                 testCaseAsync "use IAsyncDisposable sync"
                 <| async {
                     let data = 42
@@ -517,7 +512,7 @@ module AsyncExTests =
                     Expect.equal actual data "Should be able to use use"
                     Expect.isTrue wasDisposed ""
                 }
-#endif
+
                 testCaseAsync "null"
                 <| async {
                     let data = 42
@@ -773,7 +768,6 @@ module PolyfillTest =
                 let! result = async { do! Task.Yield() }
                 return result
             }
-#if TEST_NETSTANDARD2_1 || TEST_NET6_0_OR_GREATER
             testCaseAsync "use IAsyncDisposable sync"
             <| async {
                 let data = 42
@@ -792,7 +786,6 @@ module PolyfillTest =
                 Expect.equal actual data "Should be able to use use"
                 Expect.isTrue wasDisposed ""
             }
-#endif
 
             testCaseAsync
                 "Awaiting Failed Task<'T> should only contain one exception and not aggregation"

--- a/tests/IcedTasks.Tests/AsyncExTests.fs
+++ b/tests/IcedTasks.Tests/AsyncExTests.fs
@@ -675,7 +675,6 @@ module AsyncExTests =
                         }
                     )
 
-#if TEST_NETSTANDARD2_1 || TEST_NET6_0_OR_GREATER
                 yield!
                     [
                         10
@@ -688,14 +687,10 @@ module AsyncExTests =
                             let mutable index = 0
 
                             let asyncSeq: IAsyncEnumerable<_> =
-                                FSharp.Control.TaskSeq.initAsync
+                                AsyncEnumerable.forXtoY
+                                    0
                                     loops
-                                    (fun i ->
-                                        task {
-                                            do! Task.Yield()
-                                            return i
-                                        }
-                                    )
+                                    (fun _ -> valueTaskUnit { do! Task.Yield() })
 
                             let! actual =
                                 asyncEx {
@@ -718,16 +713,13 @@ module AsyncExTests =
                             async {
 
                                 let mutable index = 0
+                                let loops = 10
 
                                 let asyncSeq: IAsyncEnumerable<_> =
-                                    FSharp.Control.TaskSeq.initAsync
-                                        10
-                                        (fun i ->
-                                            task {
-                                                do! Task.Yield()
-                                                return i
-                                            }
-                                        )
+                                    AsyncEnumerable.forXtoY
+                                        0
+                                        loops
+                                        (fun _ -> valueTaskUnit { do! Task.Yield() })
 
                                 use cts = new CancellationTokenSource()
 
@@ -749,7 +741,6 @@ module AsyncExTests =
                         )
                 }
 
-#endif
             ]
         ]
 

--- a/tests/IcedTasks.Tests/CancellablePoolingValueTaskTests.fs
+++ b/tests/IcedTasks.Tests/CancellablePoolingValueTaskTests.fs
@@ -798,14 +798,10 @@ module CancellablePoolingValueTaskTests =
                             let mutable index = 0
 
                             let asyncSeq: IAsyncEnumerable<_> =
-                                FSharp.Control.TaskSeq.initAsync
+                                AsyncEnumerable.forXtoY
+                                    0
                                     loops
-                                    (fun i ->
-                                        task {
-                                            do! Task.Yield()
-                                            return i
-                                        }
-                                    )
+                                    (fun _ -> valueTaskUnit { do! Task.Yield() })
 
                             let! actual =
                                 cancellablePoolingValueTask {
@@ -830,16 +826,13 @@ module CancellablePoolingValueTaskTests =
                             cancellablePoolingValueTask {
 
                                 let mutable index = 0
+                                let loops = 10
 
                                 let asyncSeq: IAsyncEnumerable<_> =
-                                    FSharp.Control.TaskSeq.initAsync
-                                        10
-                                        (fun i ->
-                                            task {
-                                                do! Task.Yield()
-                                                return i
-                                            }
-                                        )
+                                    AsyncEnumerable.forXtoY
+                                        0
+                                        loops
+                                        (fun _ -> valueTaskUnit { do! Task.Yield() })
 
                                 use cts = new CancellationTokenSource()
 

--- a/tests/IcedTasks.Tests/CancellableTaskTests.fs
+++ b/tests/IcedTasks.Tests/CancellableTaskTests.fs
@@ -748,7 +748,6 @@ module CancellableTaskTests =
                         }
                     )
 
-#if TEST_NETSTANDARD2_1 || TEST_NET6_0_OR_GREATER
                 yield!
                     [
                         10
@@ -761,14 +760,10 @@ module CancellableTaskTests =
                             let mutable index = 0
 
                             let asyncSeq: IAsyncEnumerable<_> =
-                                FSharp.Control.TaskSeq.initAsync
+                                AsyncEnumerable.forXtoY
+                                    0
                                     loops
-                                    (fun i ->
-                                        task {
-                                            do! Task.Yield()
-                                            return i
-                                        }
-                                    )
+                                    (fun _ -> valueTaskUnit { do! Task.Yield() })
 
                             let! actual =
                                 cancellableTask {
@@ -792,16 +787,13 @@ module CancellableTaskTests =
                             cancellableTask {
 
                                 let mutable index = 0
+                                let loops = 10
 
                                 let asyncSeq: IAsyncEnumerable<_> =
-                                    FSharp.Control.TaskSeq.initAsync
-                                        10
-                                        (fun i ->
-                                            task {
-                                                do! Task.Yield()
-                                                return i
-                                            }
-                                        )
+                                    AsyncEnumerable.forXtoY
+                                        0
+                                        loops
+                                        (fun _ -> valueTaskUnit { do! Task.Yield() })
 
                                 use cts = new CancellationTokenSource()
 
@@ -821,7 +813,6 @@ module CancellableTaskTests =
                         )
                 }
 
-#endif
             ]
 
 

--- a/tests/IcedTasks.Tests/CancellableTaskTests.fs
+++ b/tests/IcedTasks.Tests/CancellableTaskTests.fs
@@ -5,9 +5,7 @@ open Expecto
 open System.Threading
 open System.Threading.Tasks
 open IcedTasks
-#if TEST_NETSTANDARD2_1 || TEST_NET6_0_OR_GREATER
-open IcedTasks.ValueTaskExtensions
-#endif
+
 module CancellableTaskTests =
     open System.Collections.Concurrent
     open TimeProviderExtensions
@@ -183,7 +181,6 @@ module CancellableTaskTests =
 
                     Expect.equal actual expected ""
                 }
-#if TEST_NETSTANDARD2_1 || TEST_NET6_0_OR_GREATER
                 testCaseAsync "Can Bind Cancellable TaskLike"
                 <| async {
                     let fooTask = fun (ct: CancellationToken) -> Task.Yield()
@@ -201,7 +198,6 @@ module CancellableTaskTests =
                         |> Async.AwaitValueTask
                 // Compiling is sufficient expect
                 }
-#endif
                 testCaseAsync "Can Bind Task"
                 <| async {
                     let outerTask = cancellableTask { do! Task.CompletedTask }
@@ -427,7 +423,6 @@ module CancellableTaskTests =
                 }
 
 
-#if TEST_NETSTANDARD2_1 || TEST_NET6_0_OR_GREATER
                 testCaseAsync "use IAsyncDisposable sync"
                 <| async {
                     let data = 42
@@ -589,7 +584,7 @@ module CancellableTaskTests =
                     Expect.equal actual data "Should be able to use use"
                     Expect.isTrue wasDisposed ""
                 }
-#endif
+
                 testCaseAsync "null"
                 <| async {
                     let data = 42

--- a/tests/IcedTasks.Tests/CancellableValueTaskTests.fs
+++ b/tests/IcedTasks.Tests/CancellableValueTaskTests.fs
@@ -786,6 +786,7 @@ module CancellableValueTaskTests =
                         }
                     )
 
+#if TEST_NETSTANDARD2_1 || TEST_NET6_0_OR_GREATER
                 yield!
                     [
                         10
@@ -857,6 +858,7 @@ module CancellableValueTaskTests =
                             }
                         )
                 }
+#endif
             ]
 
             testList "MergeSources" [

--- a/tests/IcedTasks.Tests/CancellableValueTaskTests.fs
+++ b/tests/IcedTasks.Tests/CancellableValueTaskTests.fs
@@ -786,7 +786,6 @@ module CancellableValueTaskTests =
                         }
                     )
 
-#if TEST_NETSTANDARD2_1 || TEST_NET6_0_OR_GREATER
                 yield!
                     [
                         10
@@ -799,14 +798,10 @@ module CancellableValueTaskTests =
                             let mutable index = 0
 
                             let asyncSeq: IAsyncEnumerable<_> =
-                                FSharp.Control.TaskSeq.initAsync
+                                AsyncEnumerable.forXtoY
+                                    0
                                     loops
-                                    (fun i ->
-                                        task {
-                                            do! Task.Yield()
-                                            return i
-                                        }
-                                    )
+                                    (fun _ -> valueTaskUnit { do! Task.Yield() })
 
                             let! actual =
                                 cancellableValueTask {
@@ -830,16 +825,13 @@ module CancellableValueTaskTests =
                             cancellableValueTask {
 
                                 let mutable index = 0
+                                let loops = 10
 
                                 let asyncSeq: IAsyncEnumerable<_> =
-                                    FSharp.Control.TaskSeq.initAsync
-                                        10
-                                        (fun i ->
-                                            task {
-                                                do! Task.Yield()
-                                                return i
-                                            }
-                                        )
+                                    AsyncEnumerable.forXtoY
+                                        0
+                                        loops
+                                        (fun _ -> valueTaskUnit { do! Task.Yield() })
 
                                 use cts = new CancellationTokenSource()
 
@@ -858,7 +850,7 @@ module CancellableValueTaskTests =
                             }
                         )
                 }
-#endif
+
             ]
 
             testList "MergeSources" [

--- a/tests/IcedTasks.Tests/ColdTaskTests.fs
+++ b/tests/IcedTasks.Tests/ColdTaskTests.fs
@@ -421,7 +421,6 @@ module ColdTaskTests =
                 }
 
 
-#if TEST_NETSTANDARD2_1 || TEST_NET6_0_OR_GREATER
                 testCaseAsync "use IAsyncDisposable sync"
                 <| async {
                     let data = 42
@@ -540,7 +539,7 @@ module ColdTaskTests =
                     Expect.equal actual data "Should be able to use use"
                     Expect.isTrue wasDisposed ""
                 }
-#endif
+
                 testCaseAsync "null"
                 <| async {
                     let data = 42

--- a/tests/IcedTasks.Tests/Expect.fs
+++ b/tests/IcedTasks.Tests/Expect.fs
@@ -57,7 +57,6 @@ module Expect =
             message
         |> Async.StartImmediateAsTask
 
-#if TEST_NETSTANDARD2_1 || TEST_NET6_0_OR_GREATER
     [<RequiresExplicitTypeArguments>]
     let throwsValueTask<'texn when 'texn :> exn> (f: unit -> ValueTask<unit>) message =
         throwsTAsync<'texn>
@@ -67,7 +66,7 @@ module Expect =
         |> Async.StartImmediateAsTask
         |> ValueTask<unit>
 
-#endif
+
 type Expect =
 
     static member CancellationRequested(operation: Async<_>) =
@@ -75,11 +74,10 @@ type Expect =
             (fun () -> operation)
             "Should have been cancelled"
 
-#if TEST_NETSTANDARD2_1 || TEST_NET6_0_OR_GREATER
     static member CancellationRequested(operation: ValueTask<unit>) =
         Expect.CancellationRequested(Async.AwaitValueTask operation)
         |> Async.AsValueTask
-#endif
+
     static member CancellationRequested(operation: Task<_>) =
         Expect.CancellationRequested(Async.AwaitTask operation)
         |> Async.StartImmediateAsTask
@@ -92,11 +90,11 @@ type Expect =
         Expect.CancellationRequested(Async.AwaitCancellableTask operation)
         |> Async.AsCancellableTask
 
-#if TEST_NETSTANDARD2_1 || TEST_NET6_0_OR_GREATER
+
     static member CancellationRequested(operation: CancellableValueTask<_>) =
         Expect.CancellationRequested(Async.AwaitCancellableValueTask operation)
         |> Async.AsCancellableValueTask
-#endif
+
 
 open TimeProviderExtensions
 open System.Runtime.CompilerServices

--- a/tests/IcedTasks.Tests/PoolingValueTaskDynamicTests.fs
+++ b/tests/IcedTasks.Tests/PoolingValueTaskDynamicTests.fs
@@ -608,14 +608,10 @@ module PoolingValueTaskDynamicTests =
                             let mutable index = 0
 
                             let asyncSeq: IAsyncEnumerable<_> =
-                                FSharp.Control.TaskSeq.initAsync
+                                AsyncEnumerable.forXtoY
+                                    0
                                     loops
-                                    (fun i ->
-                                        task {
-                                            do! Task.Yield()
-                                            return i
-                                        }
-                                    )
+                                    (fun _ -> valueTaskUnit { do! Task.Yield() })
 
                             let! actual =
                                 dPoolingValueTask {

--- a/tests/IcedTasks.Tests/PoolingValueTaskTests.fs
+++ b/tests/IcedTasks.Tests/PoolingValueTaskTests.fs
@@ -593,14 +593,10 @@ module PoolingValueTaskTests =
                             let mutable index = 0
 
                             let asyncSeq: IAsyncEnumerable<_> =
-                                FSharp.Control.TaskSeq.initAsync
+                                AsyncEnumerable.forXtoY
+                                    0
                                     loops
-                                    (fun i ->
-                                        task {
-                                            do! Task.Yield()
-                                            return i
-                                        }
-                                    )
+                                    (fun _ -> valueTaskUnit { do! Task.Yield() })
 
                             let! actual =
                                 poolingValueTask {

--- a/tests/IcedTasks.Tests/TaskBackgroundTests.fs
+++ b/tests/IcedTasks.Tests/TaskBackgroundTests.fs
@@ -583,7 +583,6 @@ module TaskBackgroundTests =
                             Expect.equal actual index "Should be ok"
                         }
                     )
-#if TEST_NETSTANDARD2_1 || TEST_NET6_0_OR_GREATER
                 yield!
                     [
                         10
@@ -596,14 +595,10 @@ module TaskBackgroundTests =
                             let mutable index = 0
 
                             let asyncSeq: IAsyncEnumerable<_> =
-                                FSharp.Control.TaskSeq.initAsync
+                                AsyncEnumerable.forXtoY
+                                    0
                                     loops
-                                    (fun i ->
-                                        backgroundTask {
-                                            do! Task.Yield()
-                                            return i
-                                        }
-                                    )
+                                    (fun _ -> valueTaskUnit { do! Task.Yield() })
 
                             let! actual =
                                 backgroundTask {
@@ -618,7 +613,7 @@ module TaskBackgroundTests =
                             Expect.equal actual index "Should be ok"
                         }
                     )
-#endif
+
             ]
             testList "MergeSources" [
                 testCaseAsync "and! 5"

--- a/tests/IcedTasks.Tests/TaskBackgroundTests.fs
+++ b/tests/IcedTasks.Tests/TaskBackgroundTests.fs
@@ -292,7 +292,6 @@ module TaskBackgroundTests =
                 }
 
 
-#if TEST_NETSTANDARD2_1 || TEST_NET6_0_OR_GREATER
                 testCaseAsync "use IAsyncDisposable sync"
                 <| async {
                     let data = 42
@@ -414,7 +413,6 @@ module TaskBackgroundTests =
                     Expect.equal actual data "Should be able to use use"
                     Expect.isTrue wasDisposed ""
                 }
-#endif
 
                 testCaseAsync "null"
                 <| async {

--- a/tests/IcedTasks.Tests/TaskDynamicTests.fs
+++ b/tests/IcedTasks.Tests/TaskDynamicTests.fs
@@ -302,8 +302,6 @@ module TaskDynamicTests =
                     Expect.isTrue wasDisposed ""
                 }
 
-
-#if TEST_NETSTANDARD2_1 || TEST_NET6_0_OR_GREATER
                 testCaseAsync "use IAsyncDisposable sync"
                 <| async {
                     let data = 42
@@ -425,7 +423,6 @@ module TaskDynamicTests =
                     Expect.equal actual data "Should be able to use use"
                     Expect.isTrue wasDisposed ""
                 }
-#endif
 
                 testCaseAsync "null"
                 <| async {

--- a/tests/IcedTasks.Tests/TaskDynamicTests.fs
+++ b/tests/IcedTasks.Tests/TaskDynamicTests.fs
@@ -595,7 +595,6 @@ module TaskDynamicTests =
                     )
 
 
-#if TEST_NETSTANDARD2_1 || TEST_NET6_0_OR_GREATER
                 yield!
                     [
                         10
@@ -608,14 +607,10 @@ module TaskDynamicTests =
                             let mutable index = 0
 
                             let asyncSeq: IAsyncEnumerable<_> =
-                                FSharp.Control.TaskSeq.initAsync
+                                AsyncEnumerable.forXtoY
+                                    0
                                     loops
-                                    (fun i ->
-                                        dTask {
-                                            do! Task.Yield()
-                                            return i
-                                        }
-                                    )
+                                    (fun _ -> valueTaskUnit { do! Task.Yield() })
 
                             let! actual =
                                 dTask {
@@ -630,7 +625,7 @@ module TaskDynamicTests =
                             Expect.equal actual index "Should be ok"
                         }
                     )
-#endif
+
             ]
             testList "MergeSources" [
                 testCaseAsync "and! 5"

--- a/tests/IcedTasks.Tests/TaskTests.fs
+++ b/tests/IcedTasks.Tests/TaskTests.fs
@@ -583,7 +583,6 @@ module TaskTests =
                             Expect.equal actual index "Should be ok"
                         }
                     )
-#if TEST_NETSTANDARD2_1 || TEST_NET6_0_OR_GREATER
                 yield!
                     [
                         10
@@ -596,14 +595,10 @@ module TaskTests =
                             let mutable index = 0
 
                             let asyncSeq: IAsyncEnumerable<_> =
-                                FSharp.Control.TaskSeq.initAsync
+                                AsyncEnumerable.forXtoY
+                                    0
                                     loops
-                                    (fun i ->
-                                        task {
-                                            do! Task.Yield()
-                                            return i
-                                        }
-                                    )
+                                    (fun _ -> valueTaskUnit { do! Task.Yield() })
 
                             let! actual =
                                 task {
@@ -618,7 +613,7 @@ module TaskTests =
                             Expect.equal actual index "Should be ok"
                         }
                     )
-#endif
+
             ]
             testList "MergeSources" [
                 testCaseAsync "and! 5"

--- a/tests/IcedTasks.Tests/TaskTests.fs
+++ b/tests/IcedTasks.Tests/TaskTests.fs
@@ -291,7 +291,6 @@ module TaskTests =
                 }
 
 
-#if TEST_NETSTANDARD2_1 || TEST_NET6_0_OR_GREATER
                 testCaseAsync "use IAsyncDisposable sync"
                 <| async {
                     let data = 42
@@ -414,7 +413,6 @@ module TaskTests =
                     Expect.equal actual data "Should be able to use use"
                     Expect.isTrue wasDisposed ""
                 }
-#endif
 
                 testCaseAsync "null"
                 <| async {

--- a/tests/IcedTasks.Tests/ValueTaskDynamicTests.fs
+++ b/tests/IcedTasks.Tests/ValueTaskDynamicTests.fs
@@ -594,6 +594,7 @@ module ValueTaskDynamicTests =
                         }
                     )
 
+#if TEST_NETSTANDARD2_1 || TEST_NET6_0_OR_GREATER
                 yield!
                     [
                         10
@@ -628,6 +629,7 @@ module ValueTaskDynamicTests =
                             Expect.equal actual index "Should be ok"
                         }
                     )
+#endif
             ]
             testList "MergeSources" [
                 testCaseAsync "and! 5"

--- a/tests/IcedTasks.Tests/ValueTaskDynamicTests.fs
+++ b/tests/IcedTasks.Tests/ValueTaskDynamicTests.fs
@@ -594,7 +594,6 @@ module ValueTaskDynamicTests =
                         }
                     )
 
-#if TEST_NETSTANDARD2_1 || TEST_NET6_0_OR_GREATER
                 yield!
                     [
                         10
@@ -607,14 +606,10 @@ module ValueTaskDynamicTests =
                             let mutable index = 0
 
                             let asyncSeq: IAsyncEnumerable<_> =
-                                FSharp.Control.TaskSeq.initAsync
+                                AsyncEnumerable.forXtoY
+                                    0
                                     loops
-                                    (fun i ->
-                                        task {
-                                            do! Task.Yield()
-                                            return i
-                                        }
-                                    )
+                                    (fun _ -> valueTaskUnit { do! Task.Yield() })
 
                             let! actual =
                                 dValueTask {
@@ -629,7 +624,7 @@ module ValueTaskDynamicTests =
                             Expect.equal actual index "Should be ok"
                         }
                     )
-#endif
+
             ]
             testList "MergeSources" [
                 testCaseAsync "and! 5"

--- a/tests/IcedTasks.Tests/ValueTaskTests.fs
+++ b/tests/IcedTasks.Tests/ValueTaskTests.fs
@@ -581,6 +581,8 @@ module ValueTaskTests =
                             Expect.equal actual index "Should be ok"
                         }
                     )
+
+#if TEST_NETSTANDARD2_1 || TEST_NET6_0_OR_GREATER
                 yield!
                     [
                         10
@@ -615,7 +617,9 @@ module ValueTaskTests =
                             Expect.equal actual index "Should be ok"
                         }
                     )
+#endif
             ]
+
             testList "MergeSources" [
                 testCaseAsync "and! 5"
                 <| async {

--- a/tests/IcedTasks.Tests/ValueTaskTests.fs
+++ b/tests/IcedTasks.Tests/ValueTaskTests.fs
@@ -582,7 +582,6 @@ module ValueTaskTests =
                         }
                     )
 
-#if TEST_NETSTANDARD2_1 || TEST_NET6_0_OR_GREATER
                 yield!
                     [
                         10
@@ -595,14 +594,10 @@ module ValueTaskTests =
                             let mutable index = 0
 
                             let asyncSeq: IAsyncEnumerable<_> =
-                                FSharp.Control.TaskSeq.initAsync
+                                AsyncEnumerable.forXtoY
+                                    0
                                     loops
-                                    (fun i ->
-                                        task {
-                                            do! Task.Yield()
-                                            return i
-                                        }
-                                    )
+                                    (fun _ -> valueTaskUnit { do! Task.Yield() })
 
                             let! actual =
                                 valueTask {
@@ -617,7 +612,7 @@ module ValueTaskTests =
                             Expect.equal actual index "Should be ok"
                         }
                     )
-#endif
+
             ]
 
             testList "MergeSources" [


### PR DESCRIPTION
## Proposed Changes

Lets netstandard2.0 have access to :

- `IAsyncEnumerable<T>`
- `IAsyncEnumerator<T>`
- `IAsyncDisposable<T>`
- `ValueTask`
- `ValueTask<T>`

Unsure if this is a good idea or not.

## Types of changes

What types of changes does your code introduce to IcedTasks?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Build and tests pass locally
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
