### PR TITLE
Pass CancellationToken to GetAsyncEnumerator

### DIFF
--- a/tests/IcedTasks.Tests/AsyncExTests.fs
+++ b/tests/IcedTasks.Tests/AsyncExTests.fs
@@ -741,6 +741,41 @@ module AsyncExTests =
                         )
                 }
 
+
+                testCaseAsync "IAsyncEnumerator receives CancellationToken"
+                <| async {
+                    do!
+                        asyncEx {
+
+                            let mutable index = 0
+                            let loops = 10
+
+                            let asyncSeq =
+                                AsyncEnumerable.forXtoY
+                                    0
+                                    loops
+                                    (fun _ -> valueTaskUnit { do! Task.Yield() })
+
+                            use cts = new CancellationTokenSource()
+
+                            let actual =
+                                asyncEx {
+                                    for (i: int) in asyncSeq do
+                                        do! Task.Yield()
+                                        index <- index + 1
+                                }
+
+                            do!
+                                Async.StartAsTask(actual, cancellationToken = cts.Token)
+                                |> Async.AwaitTask
+
+                            Expect.equal
+                                asyncSeq.LastEnumerator.Value.CancellationToken
+                                cts.Token
+                                ""
+                        }
+                }
+
             ]
         ]
 

--- a/tests/IcedTasks.Tests/CancellablePoolingValueTaskTests.fs
+++ b/tests/IcedTasks.Tests/CancellablePoolingValueTaskTests.fs
@@ -851,6 +851,39 @@ module CancellablePoolingValueTaskTests =
                             }
                         )
                 }
+
+
+                testCaseAsync "IAsyncEnumerator receives CancellationToken"
+                <| async {
+                    do!
+                        cancellablePoolingValueTask {
+
+                            let mutable index = 0
+                            let loops = 10
+
+                            let asyncSeq =
+                                AsyncEnumerable.forXtoY
+                                    0
+                                    loops
+                                    (fun _ -> valueTaskUnit { do! Task.Yield() })
+
+                            use cts = new CancellationTokenSource()
+
+                            let actual =
+                                cancellablePoolingValueTask {
+                                    for (i: int) in asyncSeq do
+                                        do! Task.Yield()
+                                        index <- index + 1
+                                }
+
+                            do! actual cts.Token
+
+                            Expect.equal
+                                asyncSeq.LastEnumerator.Value.CancellationToken
+                                cts.Token
+                                ""
+                        }
+                }
             ]
 
 

--- a/tests/IcedTasks.Tests/CancellableTaskTests.fs
+++ b/tests/IcedTasks.Tests/CancellableTaskTests.fs
@@ -812,6 +812,41 @@ module CancellableTaskTests =
                             }
                         )
                 }
+
+
+                testCaseAsync "IAsyncEnumerator receives CancellationToken"
+                <| async {
+
+                    do!
+                        cancellableTask {
+
+                            let mutable index = 0
+                            let loops = 10
+
+                            let asyncSeq =
+                                AsyncEnumerable.forXtoY
+                                    0
+                                    loops
+                                    (fun _ -> valueTaskUnit { do! Task.Yield() })
+
+                            use cts = new CancellationTokenSource()
+
+                            let actual =
+                                cancellableTask {
+                                    for (i: int) in asyncSeq do
+                                        do! Task.Yield()
+                                        index <- index + 1
+                                }
+
+                            do! actual cts.Token
+
+                            Expect.equal
+                                asyncSeq.LastEnumerator.Value.CancellationToken
+                                cts.Token
+                                ""
+                        }
+
+                }
             ]
             testList "MergeSources" [
 

--- a/tests/IcedTasks.Tests/CancellableValueTaskTests.fs
+++ b/tests/IcedTasks.Tests/CancellableValueTaskTests.fs
@@ -851,6 +851,39 @@ module CancellableValueTaskTests =
                         )
                 }
 
+
+                testCaseAsync "IAsyncEnumerator receives CancellationToken"
+                <| async {
+                    do!
+                        cancellableValueTask {
+
+                            let mutable index = 0
+                            let loops = 10
+
+                            let asyncSeq =
+                                AsyncEnumerable.forXtoY
+                                    0
+                                    loops
+                                    (fun _ -> valueTaskUnit { do! Task.Yield() })
+
+                            use cts = new CancellationTokenSource()
+
+                            let actual =
+                                cancellableValueTask {
+                                    for (i: int) in asyncSeq do
+                                        do! Task.Yield()
+                                        index <- index + 1
+                                }
+
+                            do! actual cts.Token
+
+                            Expect.equal
+                                asyncSeq.LastEnumerator.Value.CancellationToken
+                                cts.Token
+                                ""
+                        }
+                }
+
             ]
 
             testList "MergeSources" [


### PR DESCRIPTION
## Proposed Changes

#37 was missing passing the `CancellationToken` from a `cancellableTask` to `GetAsyncEnumerator`

## Types of changes

What types of changes does your code introduce to IcedTasks?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Build and tests pass locally
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
