### PR TITLE
Update FSharp.Control.TaskSeq to 1.1.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -26,7 +26,7 @@
     <PackageVersion Include="TimeProviderExtensions" Version="1.0.0" />
     <PackageVersion Include="YoloDev.Expecto.TestSdk" Version="0.15.3" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageVersion Include="FSharp.Control.TaskSeq" Version="0.4.0" />
+    <PackageVersion Include="FSharp.Control.TaskSeq" Version="1.1.1" />
 
     <!-- Build -->
     <PackageVersion Include="Fake.IO.FileSystem" Version="$(FakeVersion)" />


### PR DESCRIPTION
This PR updates FSharp.Control.TaskSeq dependency to a version that supports dynamic invocation without inlining.

The context is I'm working on https://github.com/dotnet/fsharp/pull/19548 which improves debugging experience by preventing inlining where possible and allowing stepping into `inline` functions and setting breakpoints there. The problem the compiler CI found is the older FSharp.Control.TaskSeq version does not allow dynamic execution, so preventing inlining there would lead to exceptions in IcedTask tests. It was implemented in https://github.com/fsprojects/FSharp.Control.TaskSeq/pull/380, and updating the version fixes the tests when no inlining is happening.